### PR TITLE
Fix kuromoji dicPath and service worker cache

### DIFF
--- a/js/analyzer.js
+++ b/js/analyzer.js
@@ -220,7 +220,7 @@ function initKuromoji() {
     kuromoji
       // ※注意: Workerから見た相対パス、または絶対URLを指定します。
       // うまく動かない場合は 'https://cdn.jsdelivr.net/npm/kuromoji@0.1.2/dict/' を指定してください。
-      .builder({ dicPath: '../dict/' }) 
+      .builder({ dicPath: 'https://cdn.jsdelivr.net/npm/kuromoji@0.1.2/dict/' })
       .build((err, tokenizer) => {
         if (err) reject(err);
         else { _tokenizer = tokenizer; resolve(); }

--- a/js/sw.js
+++ b/js/sw.js
@@ -1,9 +1,5 @@
 const CACHE_NAME = 'dict-cache-v1';
-const DICT_URLS = [
-  './dict/base.dat.gz',
-  './dict/check.dat.gz',
-  // ... 他の辞書ファイル
-];
+const DICT_URLS = [];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- `js/analyzer.js`: kuromoji の `dicPath` を存在しないローカルパス `../dict/` からCDN URL に修正
- `js/sw.js`: 存在しないローカル辞書ファイルへの参照を削除し、SW インストール失敗を解消

## Test plan
- [ ] `python3 -m http.server 8000` でローカル起動
- [ ] テキスト入力→チェック実行で結果が表示される
- [ ] DevTools Console にエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)