### PR TITLE
fix: render.yaml を Docker 構成に戻しデプロイ失敗を解消

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,10 +1,8 @@
 services:
   - type: web
     name: hyoki-checker-api
-    env: python
-    rootDir: backend
-    buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    env: docker
+    dockerfilePath: ./Dockerfile
     plan: free
     envVars:
       - key: PORT


### PR DESCRIPTION
@
## 概要
Render のデプロイがビルド失敗（`Could not open requirements file: requirements.txt`）。

## 原因
`render.yaml` が `env: python` + `rootDir: backend` だが、Render が `rootDir` を無視してルートで `pip install -r requirements.txt` を実行し、ルートに `requirements.txt` が無いため失敗していた。

## 修正
`env: docker` 構成に戻す。`Dockerfile` は `backend/requirements.txt` を絶対パスで解決し自己完結するため、`rootDir` 依存を排除できる（progress.md で実証済みの構成）。

## 注意（要確認）
Render ダッシュボードのサービスが Blueprint（render.yaml）と同期しているか要確認。手動作成サービスの場合、ランタイム設定が Docker に切り替わらないことがある。その場合はダッシュボードで Runtime を Docker に変更、または Blueprint を再同期する必要あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@